### PR TITLE
[FE-0018] common Input 컴포넌트 구현

### DIFF
--- a/@types/emotion.d.ts
+++ b/@types/emotion.d.ts
@@ -1,7 +1,7 @@
 import '@emotion/react';
 
-import { spacing } from './spacing';
-import { fontSize } from './font';
+import { spacing } from '../src/styles/spacing';
+import { fontSize } from '../src/styles/font';
 
 declare module '@emotion/react' {
   export interface Theme {

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "next-images": "^1.8.4",
         "react": "18.0.0",
         "react-dom": "18.0.0",
+        "react-hook-form": "7.31.3",
         "recoil": "0.7.2"
       },
       "devDependencies": {
@@ -5763,6 +5764,21 @@
         "scheduler": "^0.21.0"
       }
     },
+    "node_modules/react-hook-form": {
+      "version": "7.31.3",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.31.3.tgz",
+      "integrity": "sha512-NVZdCWViIWXXXlQ3jxVQH0NuNfwPf8A/0KvuCxrM9qxtP1qYosfR2ZudarziFrVOC7eTUbWbm1T4OyYCwv9oSQ==",
+      "engines": {
+        "node": ">=12.22.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/react-hook-form"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17 || ^18"
+      }
+    },
     "node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
@@ -11305,6 +11321,12 @@
         "loose-envify": "^1.1.0",
         "scheduler": "^0.21.0"
       }
+    },
+    "react-hook-form": {
+      "version": "7.31.3",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.31.3.tgz",
+      "integrity": "sha512-NVZdCWViIWXXXlQ3jxVQH0NuNfwPf8A/0KvuCxrM9qxtP1qYosfR2ZudarziFrVOC7eTUbWbm1T4OyYCwv9oSQ==",
+      "requires": {}
     },
     "react-is": {
       "version": "16.13.1",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "next-images": "^1.8.4",
     "react": "18.0.0",
     "react-dom": "18.0.0",
+    "react-hook-form": "7.31.3",
     "recoil": "0.7.2"
   },
   "devDependencies": {

--- a/src/common/ui/TextInput/TextInput.tsx
+++ b/src/common/ui/TextInput/TextInput.tsx
@@ -1,5 +1,106 @@
-import React from 'react';
+import { css, SerializedStyles, Theme } from '@emotion/react';
+import styled from '@emotion/styled';
+import { InputHTMLAttributes } from 'react';
+import { Path, RegisterOptions, useFormContext } from 'react-hook-form';
 
-export function TextInput() {
-  return <div>TextInput</div>;
+type IFormValue = {
+  [key: string]: string;
+};
+
+type Props = {
+  defaultText: string;
+  disabled?: boolean;
+  name: Path<IFormValue>;
+  placeholder?: string;
+  prefix?: React.ReactNode;
+  size?: 'medium' | 'large';
+  surfix?: React.ReactNode;
+  type?: InputHTMLAttributes<HTMLInputElement>['type'];
+  validation?: RegisterOptions;
+};
+
+type SizeTypes = Record<string, (props: Theme) => SerializedStyles>;
+
+export function TextInput({
+  defaultText,
+  disabled = false,
+  name,
+  placeholder,
+  prefix,
+  size = 'medium',
+  surfix,
+  type = 'text',
+  validation
+}: Props) {
+  const {
+    register,
+    formState: { errors }
+  } = useFormContext();
+
+  return (
+    <>
+      <InputWrapper>
+        {prefix}
+        <Input
+          {...register(name, validation)}
+          disabled={disabled}
+          $size={size}
+          placeholder={placeholder}
+          type={type}
+          defaultValue={defaultText}
+        />
+        {surfix}
+      </InputWrapper>
+      {errors[name] && <ErrorMessage>{errors[name].message}</ErrorMessage>}
+    </>
+  );
 }
+
+const sizes: SizeTypes = {
+  large: (theme: Theme) => css`
+    font-size: ${theme.fontSize.subtitle};
+    font-weight: bold;
+
+    &::placeholder {
+      color: ${theme.colors.secondary};
+      font-size: ${theme.fontSize.subtitle};
+    }
+  `,
+  medium: (theme: Theme) => css`
+    font-size: ${theme.fontSize.caption1};
+    font-weight: normal;
+
+    &::placeholder {
+      color: ${theme.colors.secondary};
+      font-size: ${theme.fontSize.caption1};
+    }
+  `
+};
+
+const Input = styled.input<{
+  $size: 'medium' | 'large';
+}>`
+  background: transparent;
+  border: none;
+  display: block;
+  flex: 1;
+  outline: none;
+
+  ${(props) => sizes[props.$size](props.theme)};
+`;
+
+const InputWrapper = styled.div`
+  align-items: center;
+  border-bottom: ${(props) => `1px solid ${props.theme.colors.onBackground}`};
+  display: flex;
+  padding-bottom: ${(props) => props.theme.spacing[2]};
+  padding-top: ${(props) => props.theme.spacing[2]};
+  width: 100%;
+`;
+
+const ErrorMessage = styled.span`
+  color: ${(props) => props.theme.colors.error};
+  display: block;
+  font-size: ${(props) => props.theme.fontSize.caption2};
+  margin-top: ${(props) => props.theme.spacing[0]};
+`;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -27,6 +27,6 @@
     "allowSyntheticDefaultImports": true,
     "incremental": true
   },
-  "include": ["src/", "next-env.d.ts", "mocks/"],
+  "include": ["src/", "next-env.d.ts", "mocks/", "@types"],
   "exclude": ["node_modules"]
 }


### PR DESCRIPTION
[[FE-0018] common Input 컴포넌트 구현](https://pricey-march-0b8.notion.site/FE-0018-common-Input-20adfe6a299a4f3f8c9515fb9e7e6d3b)

- 폼 관리 라이브러리인 `react-hook-form` 을 설치했습니다.
- RHF를 사용한 공통 text input을 구현했습니다.
- emotion의 Theme 타입을 @types 폴더로 옮겼습니다.