### PR TITLE
article 상세 페이지 구현

### DIFF
--- a/@types/emotion.d.ts
+++ b/@types/emotion.d.ts
@@ -1,7 +1,7 @@
 import '@emotion/react';
 
-import { spacing } from '../src/styles/spacing';
 import { fontSize } from '../src/styles/font';
+import { spacing } from '../src/styles/spacing';
 
 declare module '@emotion/react' {
   export interface Theme {

--- a/mocks/handlers.ts
+++ b/mocks/handlers.ts
@@ -3,26 +3,91 @@ import { rest } from 'msw';
 /**
  * TODO updatedAt 바꾸기
  */
+const content =
+  '<h2><strong>동적 경로의 정적 페이지</strong></h2><p>나는 송충이다. 그래서 솔잎을 먹고 산다. 무슨 말이냐 하면, 태어날 때부터 뼛속 깊이 문과생이라 “개발자, 기획자 몸값 최고”라는 뉴스에도 새로운 도전을 해볼 엄두를 내지 않는다는 얘기다. 그래서, 하던 일을 때려치우고 새로운 일에 도전해 성과를 낸 사람은 우선 존경하고 본다.</p><p>미국 메타(구 페이스북)에서 프로덕트 디자이너로 일하는 박주현(케일라) 씨는 그런 의미에서 솔잎을 거부한 케이스다. 그는 정치외교학을 전공하고 사회에선 영업과 마케팅 부서에서 일했다. 그러다가 서른 즈음에, 회사를 때려치우고 미국 실리콘밸리로 건너가 결국엔 메타에 입성했다. 영업이나 마케팅이 아니라 서비스 사용자경험(UX)을 만들어내는 디자이너로.</p><p>실리콘밸리의 한국인 중에 문과생 출신이 얼마나 될진 모르겠지만 어쨌든 소식을 듣자마자 이야기를 나눠보고 싶었다. 문과생이 UX 디자이너로 일하는 게 어렵지는 않은지, 실리콘밸리, 게다가 메타에서 일하는 것은 어떠한지 묻고 싶었다. 현재 탈잉에서 UX 디자인 강의도 하고 있는데, 당신과 같은 사람이 더 생기려면 교육이나 문화는 어떻게 달라져야 한다고 생각하는지도 궁금했다.</p><p>마음 넓은 주현 씨는 다행히 나의 부탁을 들어줬고, 바다 건너에 있는 관계로 줌으로 만</p><p>&nbsp;</p><figure class="image"><img src="https://publ-upload-dev.s3.ap-northeast-2.amazonaws.com/9578e2ce-a994-4603-8837-ed3b7f144ed7"></figure><p>&nbsp;</p><p>미국에 오겠다고 결정을 한 게 2018년이다. 그때만해도 UX 디자인에 대한 이해도가 한국에서는 많이 낮은 편이었다. 이왕 UX 디자인 쪽에서 일을 하고 싶다고 생각한 김에, 그 분야를 가장 선도하는 지역으로 가야겠다고 생각했다. 굉장히 야망이 있었다(웃음). 그리고 그 바람을 막연하게 희망으로만 가지고 있었던 게 아니었다. 당시 다니던 회사에서 영업, 마케팅을 담당했는데 실리콘밸리로 출장갈 일이 많았다. 현지 경험을 조금씩 해보면서 여기 와서 살면서 일해볼만하겠다고 생각했다.</p><p>&nbsp;</p><p>왜 ‘메타’냐고 묻는다면 &nbsp;실리콘밸리의 기업들도 문화가 조금씩 다르다. 메타 전에 마이크로소프트에서도 일을 해봤다. 1975년에 창업해서 지금은 임직원이 15만명이 넘는 굉장한 공룡 기업이다. 그런데 메타는 2004년에 생겨나서 굉장히 가파르게 성장한 회사다.</p><p>임직원도 5만명이 조금 넘기 때문에 마이크로소프트와 비교하면 그 규모가 3분의 1 수준이다. 규모가 작은 만큼 회사의 업무가 돌아가는 속도도 다른데, 소셜미디어처럼 굉장히 격동하는 분야에서 빠르게 일을 하는 문화가 내게는 더 맞았다. 또, 메타라는 조직이 굉장히 수평적이라 개개인에게 주는 오너십이 굉장히 크다. 리더십이 강하고 적극적이어야 하는 면모가 있는데, 그게 내 업무 스타일과 맞았다.</p><p>유리한 부분이 많고, 그래서 많은 이가 도전해줬으면 한다. 현재 (탈잉에서) “정외과 출신에 영업,마케팅을 하던 사람이 어떻게 여기서 일을 잘 할 수 있느냐”를 강의하는 이유이기도 하다.</p><p>나는 실제로 고과가 좋았고 승진도 빨리 했다. 평가가 좋은 이유를 객관적으로 설명할 수 있다. 문과생이 더 많은 도전을 해야 하는 이유가 된다. 세계적인 컨설팅 기관이 있는데, 여기에서 2013년에 미국 UX 디자이너들을 모아놓고 실무에서 가장 많이 하는 일이 무엇이냐는 설문조사를 한 적이 있다. 대답의 1, 2, 3위가 “남들을 설득시키는 일” “남 앞에서 내 아이디어를 발표하는 일” 같은, 토론이나 발표, 설득 커뮤니케이션에 관한 것이었다.</p><p>개인적인 생각으로는 UX 디자이너의 가장 중요한 역량 중 하나가 커뮤니케이션이다. 마케팅을 공부하는 문과생들이 가장 잘 하는 역할이다. 많이 쓰고 발표하고 분석하고 요약하고 비판적으로 사고하는 것은 문과생이 계속해 배우는 역량 아닌가.</p><p>전적으로 동의를 한다. &nbsp;이전에는 공부하고 학교가서 졸업할 때 되면 취업 준비를 하고, 직업을 선택하는 것이 선형적으로 진행돼왔다. 그런 시대는 진작에 끝난 것 같다. 열두살 인도 친구가 NFT 아트를 파는 시대다. (정규) 교육이라는 게 따로 있지 않고 내가 좋아하는 걸 하면서 직업을 만들고 금전적인 활동까지 할 수 있다.</p><p>전적으로 동의를 한다. &nbsp;이전에는 공부하고 학교가서 졸업할 때 되면 취업 준비를 하고, 직업을 선택하는 것이 선형적으로 진행돼왔다. 그런 시대는 진작에 끝난 것 같다. 열두살 인도 친구가 NFT 아트를 파는 시대다. (정규) 교육이라는 게 따로 있지 않고 내가 좋아하는 걸 하면서 직업을 만들고 금전적인 활동까지 할 수 있다.</p><p>&nbsp;</p><h2><strong>두 번째 인덱스</strong></h2><p>인덱스 내용</p><h2><strong>세 번째 인덱스</strong></h2>';
 
 export const handlers = [
   rest.get('https://backend/articles', (req, res, ctx) =>
     res(
       ctx.json([
         {
-          title: 'CircuitBreaker를 이용한 외부 API 장애 관리',
+          authorId: 1,
           author: '티나리',
-          thumbNail: 'https://picsum.photos/1500',
-          updatedAt: new Date().toISOString().substring(0, 10)
+          authorThumbnail: 'https://picsum.photos/1100',
+          title: 'CircuitBreaker를 이용한 외부 API 장애 관리',
+          content: content,
+          thumbnail: 'https://picsum.photos/1000',
+          id: 1,
+          tags: [
+            {
+              name: 'React',
+              id: '1'
+            },
+            {
+              name: 'SSG',
+              id: '2'
+            },
+            {
+              name: 'Next.js',
+              id: '3'
+            }
+          ],
+          createdAt: new Date().toISOString().substring(0, 10),
+          updatedAt: new Date().toISOString().substring(0, 10),
+          deletedAt: new Date().toISOString().substring(0, 10),
+          viewCount: 10,
+          isPublic: true
         },
         {
-          title: '깔끔하게 깃 관리하기 Rebase와 Merge',
+          authorId: 1,
           author: '티나리',
-          thumbNail: 'https://picsum.photos/1500',
-          updatedAt: new Date().toISOString().substring(0, 10)
+          authorThumbnail: 'https://picsum.photos/1200',
+          title: '깔끔하게 깃 관리하기 Rebase와 Merge',
+          content: content,
+          thumbnail: 'https://picsum.photos/1000',
+          id: 2,
+          tags: [],
+          createdAt: new Date().toISOString().substring(0, 10),
+          updatedAt: new Date().toISOString().substring(0, 10),
+          deletedAt: new Date().toISOString().substring(0, 10),
+          viewCount: 30,
+          isPublic: true
         }
       ])
     )
   ),
+  rest.get('https://backend/articles/:id', (req, res, ctx) => {
+    return res(
+      ctx.json({
+        authorId: 1,
+        author: '티나리',
+        authorThumbnail: 'https://picsum.photos/1100',
+        title: 'CircuitBreaker를 이용한 외부 API 장애 관리',
+        content: content,
+        thumbnail: 'https://picsum.photos/1000',
+        id: 1,
+        tags: [
+          {
+            name: 'React',
+            id: '1'
+          },
+          {
+            name: 'SSG',
+            id: '2'
+          },
+          {
+            name: 'Next.js',
+            id: '3'
+          }
+        ],
+        createdAt: new Date().toISOString().substring(0, 10),
+        updatedAt: new Date().toISOString().substring(0, 10),
+        deletedAt: new Date().toISOString().substring(0, 10),
+        viewCount: 10,
+        isPublic: true
+      })
+    );
+  }),
   rest.get('/reviews', (req, res, ctx) =>
     res(
       ctx.json([
@@ -33,5 +98,19 @@ export const handlers = [
         }
       ])
     )
-  )
+  ),
+  rest.get('https://backend/users/:id', (req, res, ctx) => {
+    return res(
+      ctx.json({
+        id: 1,
+        nickname: '티나리',
+        email: 'tnari@gmail.com',
+        pasword: 'tnari',
+        profileImage: 'https://picsum.photos/1100',
+        introduction:
+          'Svelte, rxjs, vite, AdorableCSS를 좋아하는 시니어 프론트엔드 개발자입니다. 궁금한 점이 있다면 언제든지 tnari@gmail.com로 메일 남겨주시면 즐겁게 답변드리고 있습니다.',
+        role: 'admin'
+      })
+    );
+  })
 ];

--- a/mocks/server.ts
+++ b/mocks/server.ts
@@ -1,4 +1,5 @@
 import { setupServer } from 'msw/node';
+
 import { handlers } from './handlers';
 
 export const server = setupServer(...handlers);

--- a/src/common/ui/Button/Button.tsx
+++ b/src/common/ui/Button/Button.tsx
@@ -42,7 +42,7 @@ const Container = styled.button<{
   border: none;
   font-size: ${(props) => {
     if (props.$size === 'large') {
-      return props.theme.fontSize.subtitle;
+      return props.theme.fontSize.subtitle2;
     }
 
     return props.theme.fontSize.caption2;

--- a/src/common/ui/Marquee/Marquee.tsx
+++ b/src/common/ui/Marquee/Marquee.tsx
@@ -30,7 +30,7 @@ const MarqueeText = styled.span`
   width: 89ch;
   text-shadow: 90ch 0 black, 180ch 0 black;
   white-space: nowrap;
-  font-size: ${(props) => props.theme.fontSize.subtitle};
+  font-size: ${(props) => props.theme.fontSize.subtitle2};
   font-weight: 700;
   color: ${(props) => props.theme.colors.onSurface};
 

--- a/src/common/ui/TextInput/TextInput.tsx
+++ b/src/common/ui/TextInput/TextInput.tsx
@@ -17,6 +17,7 @@ type Props = {
   surfix?: React.ReactNode;
   type?: InputHTMLAttributes<HTMLInputElement>['type'];
   validation?: RegisterOptions;
+  onClick?: (value: string) => void;
 };
 
 type SizeTypes = Record<string, (props: Theme) => SerializedStyles>;
@@ -58,12 +59,12 @@ export function TextInput({
 
 const sizes: SizeTypes = {
   large: (theme: Theme) => css`
-    font-size: ${theme.fontSize.subtitle};
+    font-size: ${theme.fontSize.subtitle2};
     font-weight: bold;
 
     &::placeholder {
       color: ${theme.colors.secondary};
-      font-size: ${theme.fontSize.subtitle};
+      font-size: ${theme.fontSize.subtitle2};
     }
   `,
   medium: (theme: Theme) => css`

--- a/src/components/about/Paragraph.tsx
+++ b/src/components/about/Paragraph.tsx
@@ -24,7 +24,7 @@ const Container = styled.div`
 
 const Title = styled.span`
   color: ${(props) => props.theme.colors.secondary};
-  font-size: ${(props) => props.theme.fontSize.subtitle};
+  font-size: ${(props) => props.theme.fontSize.subtitle2};
   font-weight: bold;
 `;
 

--- a/src/components/article/MainArticle.tsx
+++ b/src/components/article/MainArticle.tsx
@@ -1,10 +1,12 @@
 import styled from '@emotion/styled';
 import Image from 'next/image';
+import React from 'react';
 
 import { ArticleType } from '@modules/article/types/article';
 
 type Props = {
   article: ArticleType;
+  onClick: (id: number) => void;
 };
 
 /**
@@ -18,17 +20,17 @@ type Props = {
  * 따라서 절반 크기의 높이를 가지게 됩니다.
  */
 
-export function MainArticle({ article }: Props) {
+export function MainArticle({ article, onClick }: Props) {
   return (
-    <Container>
+    <Container onClick={() => onClick(article.id)}>
       <ThumbnailWrapper>
-        <Thumbnail src={article.thumbNail} layout={'fill'} priority={true} />
+        <Thumbnail src={article.thumbnail} layout={'fill'} priority={true} />
       </ThumbnailWrapper>
       <DescriptionWrapper>
         <Title>{article.title}</Title>
         <SubDescrptionBox>
           <AvatarWrapper>
-            <Avatar src={article.thumbNail} layout={'fill'} priority={true} />
+            <Avatar src={article.authorThumbnail} layout={'fill'} priority={true} />
           </AvatarWrapper>
           <Author>{article.author}</Author>
           <ArticleDate>{article.updatedAt}</ArticleDate>
@@ -42,6 +44,7 @@ const Container = styled.div`
   display: flex;
   flex: 1 1 0;
   flex-direction: column;
+  cursor: pointer;
 `;
 
 const ThumbnailWrapper = styled.div`
@@ -88,7 +91,7 @@ const SubDescrptionBox = styled.div`
 const Title = styled.div`
   max-width: 60%;
   margin-bottom: ${(props) => props.theme.spacing[5]};
-  font-size: ${(props) => props.theme.fontSize.subtitle};
+  font-size: ${(props) => props.theme.fontSize.subtitle2};
   font-family: 'Noto Sans KR', sans-serif;
   font-weight: 700;
   color: ${(props) => props.theme.colors.onSurface};

--- a/src/modules/article/types/article.ts
+++ b/src/modules/article/types/article.ts
@@ -1,6 +1,18 @@
 export type ArticleType = {
-  title: string;
+  authorId: number;
   author: string;
-  thumbNail: string;
+  authorThumbnail: string;
+  title: string;
+  content: string;
+  thumbnail: string;
+  id: number;
+  tags: {
+    name: string;
+    id: string;
+  }[];
+  createdAt: string;
   updatedAt: string;
+  deletedAt: string;
+  viewCound: number;
+  isPublic: boolean;
 };

--- a/src/modules/article/types/index.ts
+++ b/src/modules/article/types/index.ts
@@ -1,1 +1,1 @@
-export {};
+export * from './article';

--- a/src/modules/user/types/index.ts
+++ b/src/modules/user/types/index.ts
@@ -1,1 +1,1 @@
-export {};
+export * from './user';

--- a/src/modules/user/types/user.ts
+++ b/src/modules/user/types/user.ts
@@ -1,0 +1,9 @@
+export type UserType = {
+  id: number;
+  nickname: string;
+  email: string;
+  pasword: string;
+  profileImage: string;
+  introduction: string;
+  role: 'admin' | 'user';
+};

--- a/src/pages/api/articles/index.ts
+++ b/src/pages/api/articles/index.ts
@@ -1,4 +1,5 @@
 import { PrismaClient } from '@prisma/client';
+
 import type { NextApiRequest, NextApiResponse } from 'next';
 
 /**

--- a/src/pages/api/data/dto/GetArticleResponseDto.ts
+++ b/src/pages/api/data/dto/GetArticleResponseDto.ts
@@ -1,4 +1,5 @@
 import { Nullable } from '@common/utils';
+
 import { Article, Series, User } from '../model';
 
 export interface GetArticleResponseDto {

--- a/src/pages/api/data/mapper/mapGetArticlesResponseDtoToArticles.ts
+++ b/src/pages/api/data/mapper/mapGetArticlesResponseDtoToArticles.ts
@@ -1,4 +1,5 @@
 import { Mapper } from '@common/utils';
+
 import { GetArticleResponseDto } from '../dto';
 import { Article } from '../model';
 

--- a/src/pages/api/data/model/Article.ts
+++ b/src/pages/api/data/model/Article.ts
@@ -1,4 +1,5 @@
 import { Nullable } from '@common/utils';
+
 import { Series, User } from './index';
 
 export interface Article {

--- a/src/pages/api/repository/ArticleRepository.ts
+++ b/src/pages/api/repository/ArticleRepository.ts
@@ -1,4 +1,5 @@
 import Axios from 'axios';
+
 import { GetArticleResponseDto } from '../data/dto';
 import mapGetArticlesResponseDtoToArticles from '../data/mapper';
 import { Article } from '../data/model';

--- a/src/pages/articles.tsx
+++ b/src/pages/articles.tsx
@@ -1,5 +1,6 @@
 import { NextPage } from 'next/types';
 import { useQuery } from 'react-query';
+
 import { Article } from './api/data/model';
 import ArticleRepository from './api/repository';
 

--- a/src/pages/articles/[id].tsx
+++ b/src/pages/articles/[id].tsx
@@ -1,0 +1,210 @@
+import styled from '@emotion/styled';
+import { GetStaticPaths } from 'next';
+import Image from 'next/image';
+import { useEffect, useState } from 'react';
+
+import { ArticleType } from '@modules/article/types';
+import { UserType } from '@modules/user/types';
+
+type Props = {
+  article: ArticleType;
+  user: UserType;
+};
+
+function ArticleDetail({ article, user }: Props) {
+  const [index, setIndex] = useState<string[]>([]);
+
+  useEffect(() => {
+    const content = document.querySelector('#blogContent');
+    const headings: NodeListOf<HTMLHeadingElement> | undefined = content?.querySelectorAll('h2');
+
+    if (headings) {
+      const index = Array.prototype.map.call(
+        headings,
+        (heading: HTMLHeadingElement) => heading.textContent
+      );
+
+      setIndex(index as string[]);
+    }
+  }, []);
+
+  return (
+    <Container>
+      <HeaderBox>
+        <Title>{article.title}</Title>
+        <TagBox>
+          {article.tags.map((tag) => (
+            <Tag key={tag.id}>{tag.name}</Tag>
+          ))}
+          <CreatedAt>{article.updatedAt}</CreatedAt>
+        </TagBox>
+      </HeaderBox>
+      <ContentsBox>
+        <ArticleIndex>
+          {index.map((el, index) => (
+            <Index key={index} isOnView={index === 0}>
+              {el}
+            </Index>
+          ))}
+        </ArticleIndex>
+        <Content id="blogContent" dangerouslySetInnerHTML={{ __html: article.content }} />
+        <AuthorBox>
+          <AvatarWrapper>
+            <Avatar src={user.profileImage} width={140} height={140} />
+          </AvatarWrapper>
+          <Author>{user.nickname}</Author>
+          <AuthorIntroduction>{user.introduction}</AuthorIntroduction>
+        </AuthorBox>
+      </ContentsBox>
+    </Container>
+  );
+}
+
+const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  padding-left: ${(props) => props.theme.spacing[12]};
+  padding-right: ${(props) => props.theme.spacing[12]};
+`;
+
+const HeaderBox = styled.div`
+  align-items: center;
+  border-bottom: 2px solid ${(props) => props.theme.colors.onBackground};
+  display: flex;
+  flex-direction: column;
+  min-width: 40%;
+  padding-bottom: ${(props) => props.theme.spacing[10]};
+  padding-top: ${(props) => props.theme.spacing[12]};
+  width: 100%;
+`;
+
+const Title = styled.h1`
+  color: ${(props) => props.theme.colors.onBackground};
+  font-size: ${(props) => props.theme.fontSize.headline2};
+  font-weight: 900;
+  white-space: pre-wrap;
+  word-break: keep-all;
+  text-align: center;
+  margin-bottom: ${(props) => props.theme.spacing[9]};
+  max-width: 848px;
+`;
+
+const TagBox = styled.div`
+  align-items: center;
+  display: flex;
+  gap: 8px;
+`;
+
+const Tag = styled.div`
+  background-color: ${(props) => props.theme.colors.secondary};
+  color: white;
+  font-size: ${(props) => props.theme.fontSize.body2};
+  font-weight: bold;
+  padding: 6px 12px;
+`;
+
+const CreatedAt = styled(Tag)`
+  background-color: ${(props) => props.theme.colors.primary};
+  color: ${(props) => props.theme.colors.onBackground};
+`;
+
+const ContentsBox = styled.div`
+  display: flex;
+  gap: 64px;
+  padding-top: ${(props) => props.theme.spacing[8]};
+`;
+
+const Content = styled.div`
+  flex: 3;
+  font-size: ${(props) => props.theme.fontSize.caption1};
+  line-height: 40px;
+  white-space: pre-wrap;
+  word-break: keep-all;
+
+  & > h1 {
+    font-size: ${(props) => props.theme.fontSize.headline3};
+    font-weight: bold;
+  }
+
+  & > h2 {
+    font-size: ${(props) => props.theme.fontSize.subtitle1};
+    font-weight: bold;
+  }
+
+  & > h3 {
+    font-size: ${(props) => props.theme.fontSize.subtitle1};
+    font-weight: bold;
+  }
+
+  & > p {
+    font-size: ${(props) => props.theme.fontSize.subtitle2};
+    color: #0d0d0d;
+    line-height: 1.5;
+    margin-top: ${(props) => props.theme.spacing[6]};
+  }
+`;
+
+const ArticleIndex = styled.div`
+  font-size: ${(props) => props.theme.fontSize.caption2};
+  flex: 1;
+`;
+
+const AuthorBox = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 32px;
+  flex: 1;
+`;
+
+const AvatarWrapper = styled.div`
+  border-radius: 50%;
+  height: 140px;
+  overflow: hidden;
+  width: 140px;
+`;
+
+const Avatar = styled(Image)`
+  border-radius: 16px;
+`;
+
+const Author = styled.span`
+  font-size: ${({ theme }) => theme.fontSize.subtitle2};
+  font-weight: bold;
+`;
+
+const AuthorIntroduction = styled(Author)`
+  font-weight: normal;
+  line-height: 1.5;
+`;
+
+const Index = styled.div<{
+  isOnView: boolean;
+}>`
+  color: ${(props) => (props.isOnView ? props.theme.colors.primary : props.theme.colors.secondary)};
+  font-size: ${({ theme }) => theme.fontSize.body2};
+  margin-bottom: 32px;
+`;
+
+export const getStaticPaths: GetStaticPaths<{ id: string }> = async () => {
+  return {
+    paths: [],
+    fallback: 'blocking'
+  };
+};
+
+export async function getStaticProps({ params }: any) {
+  const articleResponse = await fetch(`https://backend/articles/${params.id}`);
+  const article = (await articleResponse.json()) as ArticleType;
+
+  const userResponse = await fetch(`https://backend/users/${article.authorId}`);
+  const user = (await userResponse.json()) as UserType;
+
+  return {
+    props: {
+      article,
+      user
+    }
+  };
+}
+
+export default ArticleDetail;

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,5 +1,5 @@
 import styled from '@emotion/styled';
-import type { NextPage } from 'next';
+import { useRouter } from 'next/router';
 
 import { mainWideButtonsInformation } from '@common/constants/hardCoded';
 import { Marquee } from '@common/ui';
@@ -7,13 +7,24 @@ import { MainWideButton } from '@common/ui/MainWideButton/MainWideButton';
 import { MainArticle } from '@components/article/MainArticle';
 import { ArticleType } from '@modules/article/types/article';
 
+import type { NextPage } from 'next';
+
 type Props = {
   articles: ArticleType[];
 };
 
 const Home: NextPage<Props> = ({ articles }) => {
+  const router = useRouter();
+
   const leftArticle = articles[0];
   const rightArticle = articles[1];
+
+  const handleMainArticleClick = (id: number) => {
+    router.push({
+      pathname: '/articles/[id]',
+      query: { id }
+    });
+  };
 
   return (
     <>
@@ -21,8 +32,8 @@ const Home: NextPage<Props> = ({ articles }) => {
         <Marquee />
       </MarqueeArea>
       <MainArticlesArea>
-        <MainArticle article={leftArticle} />
-        <MainArticle article={rightArticle} />
+        <MainArticle article={leftArticle} onClick={handleMainArticleClick} />
+        <MainArticle article={rightArticle} onClick={handleMainArticleClick} />
       </MainArticlesArea>
       <MainWideButtonsArea>
         {mainWideButtonsInformation.map((information, index) => (

--- a/src/styles/font.ts
+++ b/src/styles/font.ts
@@ -1,8 +1,9 @@
 export const fontSize = {
   headline1: '9.6rem',
-  headline2: '7rem',
-  headline3: '3.2rem',
-  subtitle: '2.4rem',
+  headline2: '6.0rem',
+  headline3: '4.8rem',
+  subtitle1: '3.6rem',
+  subtitle2: '2.4rem',
   body1: '2.2rem',
   body2: '1.8rem',
   caption1: '1.6rem',


### PR DESCRIPTION
article 상세 페이지를 구현했습니다.

- msw 핸들러를 추가했습니다.
  - `articles/[id]` : 단일 아티클 데이터를 가져옵니다.
  - `users/[id]` : 아티클 작성자(유저)의 정보를 가져옵니다.
  - 목데이터에 들어가는 인터페이스들을 [노션](https://pricey-march-0b8.notion.site/db-abb8a6c83e4c4ec39ad8962d6188bf03)을 참고해 작성했습니다. 
    -  posts 스키마에 author, authorThumbnail 필드가 추가되어야 할 것 같습니다!
- 댓글, 시리즈, 연관된 아티클 구현은 포함되어있지 않습니다.
- 폰트 사이즈를 조금 조정해봤는데 나중에 확인해보고 디테일 수정이 필요할 것 같습니다.

